### PR TITLE
Bump IPT to Latest Release: 2.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --update curl && \
 RUN rm -Rf /usr/local/tomcat/webapps \
     && mkdir -p /usr/local/tomcat/webapps/ROOT \
     && mkdir -p /usr/local/ipt \
-    && curl -Ls -o ipt.war http://repository.gbif.org/content/groups/gbif/org/gbif/ipt/2.3.5/ipt-2.3.5.war \
+    && curl -Ls -o ipt.war http://repository.gbif.org/content/groups/gbif/org/gbif/ipt/2.3.6/ipt-2.3.6.war \
     && unzip -d /usr/local/tomcat/webapps/ROOT ipt.war \
     && rm ipt.war
 EXPOSE 8080


### PR DESCRIPTION
Hi

We are using https://hub.docker.com/r/gbif/ipt for our ipt installation - would be nice if you could check and push an update to docker hub.

Thanks
Stein Hoem