### PR TITLE
Missing GNU sort in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV IPT_DATA_DIR=/srv/ipt
 RUN apk add --no-cache \
     curl \
     unzip \
+    coreutils \
     && rm -rf /var/cache/apk/*
 
 RUN rm -Rf /usr/local/tomcat/webapps \


### PR DESCRIPTION
Logs on ipt complain about missing or to old version of GNU sort.
This adds supportet version.
Speeds up checking for unique occurenceIds.